### PR TITLE
Fix article creation flag handling

### DIFF
--- a/src/fetchers/telegram_fetcher.py
+++ b/src/fetchers/telegram_fetcher.py
@@ -93,8 +93,8 @@ async def check_telegram_sources(user_client: Client, bot: Client, user_ids: Lis
                             "processed_at": date_utils.get_now_utc(),
                         }
 
-                        article = article_service.add_article_to_source(src.id, data)
-                        if article:
+                        created, _ = article_service.add_article_to_source(src.id, data)
+                        if created:
                             new_count += 1
 
                     source_service.update_last_checked(src, date_utils.get_now_utc())

--- a/src/services/article_service.py
+++ b/src/services/article_service.py
@@ -18,7 +18,7 @@ class ArticleService:
         self.article_repo = ArticleRepository(db)
 
     def add_article_to_source(self, source_id: int, article_data: dict) -> tuple[bool, Optional[Article]]:
-        """Добавляет статью к источнику с проверкой дубликатов"""
+        """Добавляет статью к источнику и возвращает (создано, статья)."""
         # Проверяем, нет ли уже статьи с таким id_in_source для этого источника
         existing_article = self.article_repo.get_by_source_and_external_id(
             source_id, article_data['id_in_source']
@@ -71,8 +71,8 @@ class ArticleService:
 
         for article_data in articles_data:
             try:
-                article = self.add_article_to_source(source_id, article_data)
-                if article:
+                created, _ = self.add_article_to_source(source_id, article_data)
+                if created:
                     added_count += 1
             except Exception as e:
                 logger.error(f"Ошибка при добавлении статьи: {e}")


### PR DESCRIPTION
## Summary
- ensure Telegram fetcher treats add_article_to_source return value as a creation flag
- adjust batch article creation to respect the creation flag and update the service docstring

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68fe823c50588322b52eba0c07e88373