### PR TITLE
Fix Telegram fetcher last checked tracking

### DIFF
--- a/src/fetchers/telegram_fetcher.py
+++ b/src/fetchers/telegram_fetcher.py
@@ -62,6 +62,9 @@ async def check_telegram_sources(user_client: Client, bot: Client, user_ids: Lis
                 continue
 
             new_count = 0
+            latest_article_id: Optional[int] = None
+            latest_article_processed_at = None
+            latest_external_id: Optional[int] = None
             try:
                 with source_service.update_context(src):
                     last_id = src.last_checked_article.id_in_source if src.last_checked_article else None  # type: ignore[attr-defined]
@@ -93,11 +96,21 @@ async def check_telegram_sources(user_client: Client, bot: Client, user_ids: Lis
                             "processed_at": date_utils.get_now_utc(),
                         }
 
-                        article = article_service.add_article_to_source(src.id, data)
+                        created, article = article_service.add_article_to_source(src.id, data)
                         if article:
+                            message_id = int(m.id)
+                            if latest_external_id is None or message_id > latest_external_id:
+                                latest_external_id = message_id
+                                latest_article_id = article.id
+                                latest_article_processed_at = getattr(article, "processed_at", None)
+                        if created:
                             new_count += 1
 
-                    source_service.update_last_checked(src, date_utils.get_now_utc())
+                    if latest_article_id is not None:
+                        processed_at = latest_article_processed_at or date_utils.get_now_utc()
+                        source_service.update_last_checked(src, processed_at, latest_article_id)
+                    else:
+                        source_service.update_last_checked(src, date_utils.get_now_utc())
                 if new_count:
                     logger.info("Канал %s: добавлено %d сообщений.", norm, new_count)
                 else:

--- a/src/services/source_service.py
+++ b/src/services/source_service.py
@@ -133,7 +133,7 @@ class SourceService:
 
         source.last_checked_time = last_checked_time
 
-        if last_checked_article_id:
+        if last_checked_article_id is not None:
             source.last_checked_article_id = last_checked_article_id
 
         self.db.commit()


### PR DESCRIPTION
## Summary
- let the Telegram fetcher remember the newest processed message and update the source's last checked article explicitly
- stop the article service from mutating source metadata during article creation so fetchers can manage it after batching
- allow the source service to persist last_checked_article_id even when it is zero-like

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68fe823c50588322b52eba0c07e88373